### PR TITLE
Update pdqio.cpp

### DIFF
--- a/pdq/cpp/io/pdqio.cpp
+++ b/pdq/cpp/io/pdqio.cpp
@@ -31,7 +31,7 @@ void showDecoderInfo() {
 // Returns matrix as num_rows x num_cols in row-major order.
 // The caller must free the return value.
 float* loadFloatLumaFromCImg(CImg<uint8_t>& img, int& numRows, int& numCols) {
-  if (img.spectrum() == 3) {
+  if (img.spectrum() >= 3) {
     // X,Y,Z,color -> column,row,zero,{R,G,B}
     uint8_t* pr = &img(0, 0, 0, 0);
     uint8_t* pg = &img(0, 0, 0, 1);


### PR DESCRIPTION


Summary
---------

To process PNG images, they often have an alpha channel, thus the number of channels is >3. By changing to >3, it changes nothing to jpeg processing, but allows PNG processing by ignoring the alpha channel

with this change i can hash jpeg files and png files with no problem


Test Plan
---------
I modified a copy of this repo and compiled with required for PNG processing and now i cna process png files
![image](https://github.com/user-attachments/assets/2c3fa181-5aea-473c-89dc-0463f0a325ad)
